### PR TITLE
ensure entities are not saved

### DIFF
--- a/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
@@ -40,6 +40,7 @@ object DamageDisplay  {
 
     private fun configure(textDisplay: TextDisplay) {
         with(textDisplay) {
+            isPersistent = false
             isVisibleByDefault = false
             scale(if (Config.ANIMATIONS_INCREASE_ENABLED) 0.1 else Config.DISPLAY_SCALE)
             isSeeThrough = Config.DISPLAY_SHOW_THROUGH_WALLS


### PR DESCRIPTION
Makes sure text display entities are not saved to disk when server shutdowns mid-animation.