### PR TITLE
ignore cancelled damage

### DIFF
--- a/src/main/kotlin/ru/enwulf/damagerenw/config/Config.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/config/Config.kt
@@ -11,6 +11,9 @@ object Config {
     private const val GLOBAL_SETTINGS = "global-settings"
     val SHOW_ONLY_PLAYER_DAMAGE: Boolean get() = config.getBoolean("$GLOBAL_SETTINGS.show-only-player-damage")
     val DAMAGE_TEXT_LOCATION: String? get() = config.getString("$GLOBAL_SETTINGS.text-location")
+    val DAMAGE_TEXT_LOCATION_OFFSET_X: Double get() = config.getDouble("$GLOBAL_SETTINGS.text-location-offset.x")
+    val DAMAGE_TEXT_LOCATION_OFFSET_Y: Double get() = config.getDouble("$GLOBAL_SETTINGS.text-location-offset.y")
+    val DAMAGE_TEXT_LOCATION_OFFSET_Z: Double get() = config.getDouble("$GLOBAL_SETTINGS.text-location-offset.z")
     val DISPLAY_SHOW_THROUGH_WALLS: Boolean get() = config.getBoolean("$GLOBAL_SETTINGS.display.show-through-walls")
     val DISPLAY_SCALE: Double get() = config.getDouble("$GLOBAL_SETTINGS.display.scale")
     val DISPLAY_SHADOWED: Boolean get() = config.getBoolean("$GLOBAL_SETTINGS.display.shadowed")

--- a/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
@@ -20,7 +20,7 @@ object DamageDisplay  {
 
     fun show(viewer: Player, location: Location, message: String, replacements: Map<String, String>? = null) {
         val textDisplay = create(
-            location.clone().add(Config.DAMAGE_TEXT_LOCATION_OFFSET_X, Config.DAMAGE_TEXT_LOCATION_OFFSET_Y, Config.DAMAGE_TEXT_LOCATION_OFFSET_Z),
+            location.add(Config.DAMAGE_TEXT_LOCATION_OFFSET_X, Config.DAMAGE_TEXT_LOCATION_OFFSET_Y, Config.DAMAGE_TEXT_LOCATION_OFFSET_Z),
             message,
             replacements
         )

--- a/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
@@ -19,7 +19,11 @@ import ru.enwulf.damagerenw.config.Config
 object DamageDisplay  {
 
     fun show(viewer: Player, location: Location, message: String, replacements: Map<String, String>? = null) {
-        val textDisplay = create(location, message, replacements)
+        val textDisplay = create(
+            location.clone().add(Config.DAMAGE_TEXT_LOCATION_OFFSET_X, Config.DAMAGE_TEXT_LOCATION_OFFSET_Y, Config.DAMAGE_TEXT_LOCATION_OFFSET_Z),
+            message,
+            replacements
+        )
 
         configure(textDisplay)
 

--- a/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/display/CustomTextDisplay.kt
@@ -40,6 +40,7 @@ object DamageDisplay  {
 
     private fun configure(textDisplay: TextDisplay) {
         with(textDisplay) {
+            isPersistent = false
             isVisibleByDefault = false
             scale(if (Config.ANIMATIONS_INCREASE_ENABLED) 0.1 else Config.DISPLAY_SCALE)
             isSeeThrough = Config.DISPLAY_SHOW_THROUGH_WALLS

--- a/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
@@ -18,7 +18,7 @@ class DamageListener : Listener {
 
     private val killTracker = KillTracker()
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun EntityDamageByEntityEvent.handle() {
         val damagedEntity = entity as? LivingEntity ?: return
 

--- a/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
@@ -21,7 +21,7 @@ class DamageListener : Listener {
     @EventHandler
     fun EntityDamageByEntityEvent.handle() {
         val damagedEntity = entity as? LivingEntity ?: return
-        if (damagedEntity.hasMetadata("NPC")) return
+
         if (Config.SHOW_ONLY_PLAYER_DAMAGE && damagedEntity !is Player) return
         if (Config.IGNORE_ZERO_DAMAGE && finalDamage <= 0) return
 

--- a/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
@@ -21,7 +21,7 @@ class DamageListener : Listener {
     @EventHandler
     fun EntityDamageByEntityEvent.handle() {
         val damagedEntity = entity as? LivingEntity ?: return
-
+        if (damagedEntity.hasMetadata("NPC")) return
         if (Config.SHOW_ONLY_PLAYER_DAMAGE && damagedEntity !is Player) return
         if (Config.IGNORE_ZERO_DAMAGE && finalDamage <= 0) return
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,12 @@ global-settings:
   # Available options: [ head, eye, body ]
   text-location: eye
 
+  # Specifies the offset which is applied to the spawn location.
+  text-location-offset:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+
   # animations settings
   animations:
     increase:


### PR DESCRIPTION
Plugins like **[WorldGuard](https://github.com/EngineHub/WorldGuard)** can cancel damage in specific areas like spawn for example. This PR should prevent text displays from appearing when the `EntityDamageByEntityEvent` is cancelled.