### PR TITLE
ignore cancelled damage

### DIFF
--- a/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
+++ b/src/main/kotlin/ru/enwulf/damagerenw/listeners/DamgerListener.kt
@@ -18,7 +18,7 @@ class DamageListener : Listener {
 
     private val killTracker = KillTracker()
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun EntityDamageByEntityEvent.handle() {
         val damagedEntity = entity as? LivingEntity ?: return
 


### PR DESCRIPTION
Plugins like **[WorldGuard](https://github.com/EngineHub/WorldGuard)** can cancel damage in specific areas like spawn for example. This PR should prevent text displays from appearing when the `EntityDamageByEntityEvent` is cancelled.